### PR TITLE
fix: navigation links causing a hydration failure

### DIFF
--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -31,9 +31,11 @@ export default function Navbar() {
 
           {baseNavigation.map((item) => (
             <NavigationMenuItem key={item.name}>
-              <Link to={item.href}>
-                <NavigationMenuLink className={navigationMenuTriggerStyle()}>{item.name}</NavigationMenuLink>
-              </Link>
+              <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+                <Link to={item.href}>
+                  {item.name}
+                </Link>
+              </NavigationMenuLink>
             </NavigationMenuItem>
           ))}
           <NavigationMenuItem>


### PR DESCRIPTION
# Summary
The navigation links were causing a mismatch between server-rendered and client-rendered HTML, leading to failures during hydration.

## Changes
Updated the implementation to render the Remix `Link` component inside the `NavigationMenuLink` using the `asChild` attribute. This resolves the hydration mismatch by ensuring consistent HTML on both server and client.

---

## Context
This repository was a helpful reference for me while integrating Remix links with the Navigation Menu in my project, I encountered a hydration error that this change fixes so I wanted to contribute back by resolving this issue for anyone who might face the same problem in the future.